### PR TITLE
Add copy button and location display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # whatismyIP
 
-It magically tells your IP address. Voila!
+A tiny web page that tells you your public IP address.
+
+## Features
+
+* Displays the detected IP address.
+* **Copy IP** button to quickly copy the address to your clipboard.
+* Shows your approximate location (city and country).

--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
     <div class="outer">
         <div class="main-content">
             <input type="text" id="ip-address" placeholder="IP Address" disabled="">
+            <button id="copy-ip" disabled>Copy IP</button>
+            <p id="location"></p>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -1,11 +1,28 @@
-let ip=document.querySelector('#ip-address');
+let ipInput = document.querySelector('#ip-address');
+let copyBtn = document.querySelector('#copy-ip');
+let locationField = document.querySelector('#location');
+
 fetch('https://api.ipify.org/?format=json')
-    .then(response => {
-        return response.json();
-    })
+    .then(response => response.json())
     .then(json => {
-        ip.value = json.ip;
-    })    
-    .catch(err => {
-        ip.value = 'Unable to fetch IP';
+        ipInput.value = json.ip;
+        copyBtn.disabled = false;
+    })
+    .catch(() => {
+        ipInput.value = 'Unable to fetch IP';
+    });
+
+copyBtn.addEventListener('click', () => {
+    navigator.clipboard.writeText(ipInput.value).catch(() => {
+        /* ignore copy errors */
+    });
+});
+
+fetch('https://ipapi.co/json')
+    .then(response => response.json())
+    .then(data => {
+        locationField.textContent = `${data.city}, ${data.country_name}`;
+    })
+    .catch(() => {
+        locationField.textContent = 'Unable to fetch location';
     });

--- a/styles.css
+++ b/styles.css
@@ -29,7 +29,8 @@ header {
     width: 100%;
 }
 
-.main-content {position: absolute;
+.main-content {
+    position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, 50%);
@@ -40,10 +41,11 @@ header {
     border-radius: 8px;
     box-shadow: 0 1px 5px rgb(97 97 97);
     margin: auto;
-    /*margin-top: 210px;*/
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
+    gap: 10px;
 }
 
 input[type=text] {
@@ -61,6 +63,27 @@ input[type=text] {
     align-items: center;
     font-size: 26px;
     text-align: center;
+}
+
+#copy-ip {
+    padding: 8px 12px;
+    border: none;
+    border-radius: 4px;
+    background-color: #e1bb80;
+    color: rgb(1, 54, 70);
+    font-weight: bold;
+    cursor: pointer;
+    box-shadow: 0 1px 5px rgb(97 97 97);
+}
+
+#copy-ip:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+#location {
+    color: rgb(1, 54, 70);
+    font-size: 18px;
 }
 
 /* footer CSS */


### PR DESCRIPTION
## Summary
- add copy button and location field to HTML
- fetch location data and implement copy functionality
- style button and location area
- document new capabilities

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6856eee75b088325ac56c6e16a8d7e70